### PR TITLE
PrivilegeAuthorizer: silent fail on unknown role privilege

### DIFF
--- a/tests/Unit/Authorization/PrivilegeAuthorizerTest.php
+++ b/tests/Unit/Authorization/PrivilegeAuthorizerTest.php
@@ -606,6 +606,7 @@ final class PrivilegeAuthorizerTest extends TestCase
 	public function testAllowChecksPrivilege(): void
 	{
 		$authorizer = new PrivilegeAuthorizer();
+		$authorizer->throwOnUnknownRolePrivilege = true;
 		$authorizer->addRole('role');
 
 		$this->expectException(InvalidState::class);
@@ -619,6 +620,7 @@ final class PrivilegeAuthorizerTest extends TestCase
 	public function testDenyChecksPrivilege(): void
 	{
 		$authorizer = new PrivilegeAuthorizer();
+		$authorizer->throwOnUnknownRolePrivilege = true;
 		$authorizer->addRole('role');
 
 		$this->expectException(InvalidState::class);
@@ -626,6 +628,18 @@ final class PrivilegeAuthorizerTest extends TestCase
 			'Privilege unknown is unknown, add with addPrivilege() before calling Orisai\Auth\Authorization\PrivilegeAuthorizer->deny()',
 		);
 
+		$authorizer->deny('role', 'unknown');
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function testAssigningUnknownRolePrivilegeDoesNotFailByDefault(): void
+	{
+		$authorizer = new PrivilegeAuthorizer();
+		$authorizer->addRole('role');
+
+		$authorizer->allow('role', 'unknown');
 		$authorizer->deny('role', 'unknown');
 	}
 


### PR DESCRIPTION
```php
$authorizer = new PrivilegeAuthorizer();
$authorizer->addRole('role');

$authorizer->allow('role', 'unknown');
$authorizer->deny('role', 'unknown');
```

This code would throw exception before this PR, because call `$authorizer->addPrivilege('unknown')` is missing. That exception is no longer thrown and because of that are `allow()` and `deny()` methods doing effectively nothing.

Reason for the new behavior is it may be hard to remove persisted role privileges. Imagine this structure:

```
✓ forum
	✓ post
		✓ publish
```

We have an privilege for forum post to be published. It can be stored in role in database as `forum.post.publish`, `forum.post`, `forum` or `*`. If we wan't remove `forum.post.publish` from application, all of these (except `*`) have to be removed from stored role, otherwise exception would be thrown. Itself not so hard problem, but in modular systems `forum.post` could have other subprivileges, unknown to the code from which was `forum.post.publish` removed. See following example:

```
✓ forum
	✓ post
		✓ publish (defined by forum package)
		✓ approve (defined by forum-extending package)
```

We have multiple subprivileges in `forum.post` which possibly are defined by many packages. Any code removing privileges would have to account that and only remove `forum.post.publish` in case `forum.post` have any other privileges. Such conditional privileges removal may be too complicated for user and has very little added value in checking data integrity.

Considering that unknown privilege still throw on `isAllowed()` and the only requirement for the correctly working code is to call `addPrivilege()` before `allow()` or `deny()` is impact of this change pretty low.

To reintroduce previous behavior (for debugging purposes), `$authorizer->throwOnUnknownRolePrivilege` can be set to `true`.